### PR TITLE
Changes to read_inp_mod so MPI Masking can work.

### DIFF
--- a/src/cstar_output.F
+++ b/src/cstar_output.F
@@ -14,10 +14,9 @@
       use bgc_shared_vars, only:
      &     t, bgc_diag_2d, mynode, lm, mm,
      &     nr_bgc_diag_2d, vname_bgc_diag_2d, t_lname
-      use dimensions, only: i0, i1, j0, j1, nx, ny, nz
+      use dimensions, only: i0, i1, j0, j1, nx, ny, nz, eta_rho, xi_rho
       use roms_read_write, only:
-     &     dn_tm, dn_xr, dn_yr, dn_zr, eta_rho,
-     &     xi_rho, create_file
+     &     dn_tm, dn_xr, dn_yr, dn_zr, create_file
       use nc_read_write, only: nccreate, ncwrite
       use netcdf, only:
      &     nf90_noerr, nf90_write, nf90_double, nf90_open,

--- a/src/read_inp_mod.F
+++ b/src/read_inp_mod.F
@@ -1,6 +1,6 @@
       module read_inp_mod
 
-      use param, only: mynode, nnodes, ocean_grid_comm
+      use param, only: mynode, nnodes, ocean_grid_comm, nsize
       use mpi_f08, only: mpi_byte
       use roms_read_write, only: git_hash
       use keyword_registry, only:
@@ -933,7 +933,7 @@
       lstr = lenstr(fname)
 
 # if defined MPI && defined PARALLEL_FILES
-      call insert_node(fname, lstr, mynode, NNODES, ierr)
+      call insert_node(fname, lstr, mynode, nsize, ierr)
 # endif
 
       open(newunit=testunit, file=fname(1:lstr), status='old',
@@ -981,7 +981,7 @@
          lstr = lenstr(fname)
 
 # if defined MPI && defined PARALLEL_FILES
-         call insert_node(fname, lstr, mynode, NNODES, ierr)
+         call insert_node(fname, lstr, mynode, nsize, ierr)
 # endif
          open(newunit=testunit, file=fname(1:lstr), status='old',
      &        iostat=ios)
@@ -1034,7 +1034,7 @@
          if (lstr > 0) then
 
 # if defined MPI && defined PARALLEL_FILES
-            call insert_node(fname, lstr, mynode, NNODES, ierr)
+            call insert_node(fname, lstr, mynode, nsize, ierr)
 # endif
 
 ! Test file availability
@@ -1116,7 +1116,7 @@
       lstr = lenstr(fname)
 
 # if defined MPI && defined PARALLEL_FILES
-      call insert_node(fname, lstr, mynode, NNODES, ierr)
+      call insert_node(fname, lstr, mynode, nsize, ierr)
 # endif
 
       open(newunit=testunit, file=fname(1:lstr), status='old',


### PR DESCRIPTION
In read_inp_mod.F I had to change "NNODES" to "nsize" in calls to insert_node.F, since with MPI_Masking NNODES is no longer set at startup. This was causing simulations to crash any time the run would use 10 or more cores.

Also, a minor bugfix in cstar_output, also for compatibility with MPI_Masking.